### PR TITLE
Allow backwards travel

### DIFF
--- a/T_run_mcl.py
+++ b/T_run_mcl.py
@@ -6,7 +6,6 @@ import montecarlo_localization as mcl
 import os, sys
 
 def main(filename='./mcl_test_arena.mp4'):
-    
     np.random.seed(5)
     loaded_map = mcl.occupancy_map('data/map/test_arena.dat')
     logdata = mcl.load_T_log('data/log/data_2020-02-22_19-55-08_998399.log')
@@ -39,6 +38,7 @@ class ParticleMap(object):
         self.i = 1
         self.target_particles = target_particles
         self.resample_period = resample_period
+        self.average_path = []
 
     def update(self, message):
         if self.i % self.resample_period == 0:# Resample and plot state
@@ -50,6 +50,10 @@ class ParticleMap(object):
                 sum_x += p.pose[0]
                 sum_y += p.pose[1]
             average_particle = [sum_x/len(self.particle_list), sum_y/len(self.particle_list), message[5]]
+            self.average_path.append(average_particle)
+            cx = [row[0] for row in self.average_path]
+            cy = [row[1] for row in self.average_path]
+            self.ax.plot(cx, cy,"-k")
             mcl.draw_map_state(self.global_map, self.particle_list, self.ax, draw_max=self.draw_max)
             mcl.plot_particle(average_particle, self.ax, pass_pose=True, color='r')
             #print(pd.Series([p.weight for p in self.particle_list]).describe())

--- a/T_run_mcl.py
+++ b/T_run_mcl.py
@@ -9,7 +9,7 @@ def main(filename='./mcl_test_arena.mp4'):
     
     np.random.seed(5)
     loaded_map = mcl.occupancy_map('data/map/test_arena.dat')
-    logdata = mcl.load_T_log('data/log/test_arena.dat')
+    logdata = mcl.load_T_log('data/log/data_2020-02-22_19-55-08_998399.log')
     logdata_scans = logdata.query('type > 0.1').values
     #Initialize 100 particles uniformly in valid locations on the map
     laser = mcl.laser_sensor(stdv_cm=2, uniform_weight=0.2)

--- a/montecarlo_localization.py
+++ b/montecarlo_localization.py
@@ -355,12 +355,16 @@ class robot_particle():
         log_delta_theta = new_log_pose[2] - self.prev_log_pose[2]
         # Fwd motion in log frame == Fwd motion in particle framea
         fwd_motion = math.sqrt(log_delta_x**2 + log_delta_y**2)
+        motion_heading = math.atan2(log_delta_y, log_delta_x)
+        
         # Calculate and add stochastic theta and forward error
         new_theta_error = log_delta_theta * self.sigma_theta_pct * np.random.normal()
         new_current_theta = self.pose[2] + log_delta_theta + new_theta_error
         # Wrap radians to enforce range 0 to 2pi
         new_current_theta = new_current_theta % (2*np.pi)
-
+        heading_vs_direction_angle = abs(motion_heading-new_current_theta+np.pi) % (2*np.pi)-np.pi
+        if (abs(heading_vs_direction_angle) > (np.pi/2)):
+            fwd_motion = -fwd_motion
         fwd_motion_error = fwd_motion * self.sigma_fwd_pct * np.random.normal()
         fwd_motion += fwd_motion_error
         new_current_x = self.pose[0] + fwd_motion * np.cos(new_current_theta)

--- a/montecarlo_localization.py
+++ b/montecarlo_localization.py
@@ -363,7 +363,7 @@ class robot_particle():
         # Wrap radians to enforce range 0 to 2pi
         new_current_theta = new_current_theta % (2*np.pi)
         heading_vs_direction_angle = abs(motion_heading-new_current_theta+np.pi) % (2*np.pi)-np.pi
-        if (abs(heading_vs_direction_angle) > (np.pi/2)):
+        if abs(heading_vs_direction_angle) > (np.pi / 2):
             fwd_motion = -fwd_motion
         fwd_motion_error = fwd_motion * self.sigma_fwd_pct * np.random.normal()
         fwd_motion += fwd_motion_error


### PR DESCRIPTION
I think I may have introduced a new error when I 'fixed' an error in `new_pose_from_log_delta` This change checks the difference in 'heading' between the pose's heading and the movement direction and applys the move direction (mostly) appropriately. it used to always apply the move distance in the direction of the pose's heading (forwards)
This PR includ es some other changes covered in other PR's (oops). only commit 88597bcb001040173386c0f630d135d09ac428b9 changes the travel
This change works but I think might have some assumptions or inefficiencies in it.